### PR TITLE
Fix TOC markdown/display issues for forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Amazon AWS
 
-Table of contents
+## Table of contents
+
 1. [Description](#description)
 2. [Setup](#setup)
    * [Install the module](#installing-the-module)


### PR DESCRIPTION
The table of contents displays weirdly on the forge, likely because there isn't a blank line between "Table of contents" and the numbered list. Hopefully this remedies the situation.